### PR TITLE
feat: implement tag listing command

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -156,8 +156,15 @@ var commands = map[string]CommandFunc{
 		}
 	},
 	"tag": func(args []string) {
+		if len(args) == 0 || (len(args) > 0 && args[0] == "--list") {
+			if err := core.ListTags(); err != nil {
+				fmt.Println("Error:", err)
+			}
+			return
+		}
 		if len(args) < 2 {
 			fmt.Println("Usage: kitkat tag <tag-name> <commit-id>")
+			fmt.Println("   or: kitkat tag --list")
 			return
 		}
 		if err := core.CreateTag(args[0], args[1]); err != nil {

--- a/internal/core/tag.go
+++ b/internal/core/tag.go
@@ -22,3 +22,40 @@ func CreateTag(tagName, commitID string) error {
 	fmt.Printf("Tag '%s' created for commit %s\n", tagName, commitID)
 	return nil
 }
+
+// ListTags prints all existing tags and the commit they point to
+func ListTags() error {
+	if _, err := os.Stat(tagsDir); os.IsNotExist(err) {
+		fmt.Println("No tags found.")
+		return nil
+	}
+
+	entries, err := os.ReadDir(tagsDir)
+	if err != nil {
+		return err
+	}
+
+	if len(entries) == 0 {
+		fmt.Println("No tags found.")
+		return nil
+	}
+
+	fmt.Println("Tags:")
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		tagName := entry.Name()
+		tagPath := filepath.Join(tagsDir, tagName)
+		commitBytes, err := os.ReadFile(tagPath)
+		if err != nil {
+			fmt.Printf("  %s (error reading commit ID)\n", tagName)
+			continue
+		}
+
+		fmt.Printf("  %s -> %s\n", tagName, string(commitBytes))
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description
Implemented the **kitkat tag --list** command. This feature allows users to display all tags stored in the repository.
**Fixes #3** 

# Implementation Details
**Modified** 
internal/core/tag.go

**Added :**
ListTags function to read entries from .kitkat/refs/tags/ and print them.
Modified cmd/main.go: Updated the tag command to check for the --list flag or no arguments, calling core.ListTags() accordingly.

# Verification (Mandatory)
<img width="993" height="480" alt="Screenshot 2025-12-27 204804" src="https://github.com/user-attachments/assets/b751f0db-ad15-4ce2-9b64-ad8eeba734c4" />


# Track Selection
- Track 3: Systems Engineering

# Code Style
Ran go fmt ./... for formatting compliance.

**Part of Social Winter of Code (SWOC) 2026**