### PR TITLE
fix: abort merge when working directory is dirty

### DIFF
--- a/internal/core/merge.go
+++ b/internal/core/merge.go
@@ -12,6 +12,15 @@ import (
 // Merge attempts to merge the given branch into the current branch
 // Currently only supports fast-forward merges
 func Merge(branchToMerge string) error {
+	// Pre-flight check to prevent overwriting local changes
+	dirty, err := IsWorkDirDirty()
+	if err != nil {
+		return err
+	}
+	if dirty {
+		return fmt.Errorf("your local changes would be overwritten by merge")
+	}
+
 	// Getting the commit hash of the branch to merge
 	branchPath := filepath.Join(headsDir, branchToMerge)
 	featureHeadHashBytes, err := os.ReadFile(branchPath)


### PR DESCRIPTION
# Description

`Fixes :`#13

This PR adds a safety check to the kitkat merge command to prevent uncommitted local changes from being overwritten during a merge operation.

# Implementation Details

- Added a pre-flight check at the beginning of the Merge function in
```bash
internal/core/merge.go
```
- Reused the existing `IsWorkDirDirty()` helper already used in the checkout logic for consistency

- Aborts the merge early with a clear error message when the working directory contains uncommitted changes

# Result

- Merge now aborts safely when the working directory is dirty

- Error message clearly informs the user of the conflict

- Behavior is consistent with checkout safety checks

- Prevents accidental data loss

# Verification
```bash
$ echo "Version Local" > hello.txt
$ kitkat merge feature
```
# Output
```bash
your local changes would be overwritten by merge
```
<img width="1111" height="210" alt="merge error output" src="https://github.com/user-attachments/assets/5f59f28c-bbd9-4b8b-bbee-54a7d448cd8e" />
hello.txt (unchanged)
<img width="1370" height="174" alt="hello.txt unchanged" src="https://github.com/user-attachments/assets/6639414d-eacf-4233-aca2-27e7beacba0d" />

# Track Selection

- [x] Track 1: Beginner Code

- [x] Track 3: Systems Engineering

# Checklist

- [x] My code follows the style guidelines of this project

- [x]  I have performed a self-review of my own code

- [x] I have reused existing project logic where applicable

- [x] I have run go fmt ./... locally

- [x] I have verified all acceptance criteria listed in the issue