### PR TITLE
Fix: Fixed the checkout -b command

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -108,13 +108,17 @@ var commands = map[string]CommandFunc{
 	},
 	"checkout": func(args []string) {
 		if len(args) < 1 {
-			fmt.Println("Usage: kitkat checkout <branch-name | file-path>")
+			fmt.Println("Usage: kitkat checkout [-b] <branch-name> | <file-path>")
 			return
 		}
-		if len(args) >= 2 && args[0] == "-b" {
+		if args[0] == "-b" {
+			if len(args) != 2 {
+				fmt.Println("Usage: kitkat checkout -b <branch-name>")
+				return
+			}
 			name := args[1]
 			if core.IsBranch(name) {
-				fmt.Println("Error: Branch already exists")
+				fmt.Printf("Error: Branch '%s' already exists\n", name)
 				return
 			}
 			if err := core.CreateBranch(name); err != nil {


### PR DESCRIPTION
# Description
Fixes #12
- Add support for `kitkat checkout -b <branch>` to create and switch in one step
- Preserve existing behavior for branch/file checkout without `-b`
- Returns error when branch already exists

# Implementation Details
- Parse `-b` flag in checkout handler; create branch then checkout branch
- Fallback: single-arg checkout still handles branch switch or file restore
- Added early returns for clear error handling

# Verification (Mandatory)
- go run cmd/main.go checkout -b demo-pr-branch
- go run cmd/main.go branch   # shows * demo-pr-branch active
- go run cmd/main.go checkout main
- go run cmd/main.go checkout main   # no-op but works; switches back

# Track Selection
- [x] Track 1: Beginner Code
- [ ] Track 2: Visual Documentation
- [ ] Track 3: Intermediate Code

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (not needed here)
- [x] I have run `go fmt ./...` locally
- [x] I have verified all "Acceptance Criteria" listed in the issue