### PR TITLE
feat: implement kitkat commit --amend

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,45 +36,75 @@ var commands = map[string]CommandFunc{
 		}
 	},
 	"commit": func(args []string) {
-		if len(args) < 2 {
-			fmt.Println("Usage: kitkat commit <-m | -am> <message>")
+		if len(args) < 1 {
+			fmt.Println("Usage: kitkat commit <-m | -am | --amend> <message>")
 			return
 		}
 
 		var message string
-		var commitFunc func(string) (models.Commit, string, error)
+		var isAmend bool
 
-		switch args[0] {
-		case "-am":
-			message = strings.Join(args[1:], " ")
-			commitFunc = core.CommitAll
-		case "-m":
-			message = strings.Join(args[1:], " ")
-			commitFunc = core.Commit
-		default:
+		// Check for --amend flag
+		if args[0] == "--amend" {
+			if len(args) < 3 || args[1] != "-m" {
+				fmt.Println("Usage: kitkat commit --amend -m <message>")
+				return
+			}
+			isAmend = true
+			message = strings.Join(args[2:], " ")
+		} else if len(args) < 2 {
 			fmt.Println("Usage: kitkat commit <-m | -am> <message>")
 			return
-		}
-
-		newCommit, summary, err := commitFunc(message)
-		if err != nil {
-			if err.Error() == "nothing to commit, working tree clean" {
-				fmt.Println(err.Error())
-			} else {
-				fmt.Println("Error:", err)
+		} else {
+			// Normal commit flow
+			switch args[0] {
+			case "-am":
+				message = strings.Join(args[1:], " ")
+				newCommit, summary, err := core.CommitAll(message)
+				if err != nil {
+					if err.Error() == "nothing to commit, working tree clean" {
+						fmt.Println(err.Error())
+					} else {
+						fmt.Println("Error:", err)
+					}
+					return
+				}
+				printCommitResult(newCommit, summary)
+				return
+			case "-m":
+				message = strings.Join(args[1:], " ")
+			default:
+				fmt.Println("Usage: kitkat commit <-m | -am | --amend> <message>")
+				return
 			}
-			return
 		}
 
-		headState, err := core.GetHeadState()
-		if err != nil {
-			// Fallback in case GetHeadState fails on the very first commit before ref exists
-			headData, _ := os.ReadFile(".kitkat/HEAD")
-			ref := strings.TrimSpace(string(headData))
-			headState = strings.TrimPrefix(ref, "ref: refs/heads/")
+		// Handle amend or normal commit
+		if isAmend {
+			newCommit, err := core.AmendCommit(message)
+			if err != nil {
+				fmt.Println("Error:", err)
+				return
+			}
+			headState, err := core.GetHeadState()
+			if err != nil {
+				headData, _ := os.ReadFile(".kitkat/HEAD")
+				ref := strings.TrimSpace(string(headData))
+				headState = strings.TrimPrefix(ref, "ref: refs/heads/")
+			}
+			fmt.Printf("[%s %s] %s (amended)\n", headState, newCommit.ID[:7], newCommit.Message)
+		} else {
+			newCommit, summary, err := core.Commit(message)
+			if err != nil {
+				if err.Error() == "nothing to commit, working tree clean" {
+					fmt.Println(err.Error())
+				} else {
+					fmt.Println("Error:", err)
+				}
+				return
+			}
+			printCommitResult(newCommit, summary)
 		}
-
-		fmt.Printf("[%s %s] %s\n%s\n", headState, newCommit.ID[:7], newCommit.Message, summary)
 	},
 	"log": func(args []string) {
 		oneline := false
@@ -188,6 +218,17 @@ var commands = map[string]CommandFunc{
 			fmt.Println("Usage: kitkat config --global <key> [<value>]")
 		}
 	},
+}
+
+// printCommitResult formats and prints the commit result with summary
+func printCommitResult(newCommit models.Commit, summary string) {
+	headState, err := core.GetHeadState()
+	if err != nil {
+		headData, _ := os.ReadFile(".kitkat/HEAD")
+		ref := strings.TrimSpace(string(headData))
+		headState = strings.TrimPrefix(ref, "ref: refs/heads/")
+	}
+	fmt.Printf("[%s %s] %s\n%s\n", headState, newCommit.ID[:7], newCommit.Message, summary)
 }
 
 func main() {


### PR DESCRIPTION
## Description
Implements `kitkat commit --amend` feature that allows users to update the most recent commit message without changing file contents.

Fixes #28

## Changes Made
- Modified `cmd/main.go` to parse `--amend` flag with `-m` message
- Added `AmendCommit()` function in `internal/core/commit.go`
- Commit is re-hashed with new message, generating a new commit ID
- Branch pointer is updated to point to the new commit
- Preserves original timestamp and author information

## Testing Output

**Test 1: Basic Amend Functionality**
```
$ ./kitkat init
Initialized empty KitKat repository in ./.kitkat/

$ echo "Hello World" > test.txt
$ ./kitkat add test.txt
$ ./kitkat commit -m "Initial commit with a typo"
[main 9277233] Initial commit with a typo
1 file changed, 2 insertions(+), 0 deletions(-)

$ ./kitkat log
commit 9277233c2fab5e598d47826279a4a060b5479906
Author: shatrughan mishra <shatrughanm485@gmail.com>
Date:   Thu Jan 01 14:35:05 2026 +0530
    Initial commit with a typo

$ ./kitkat commit --amend -m "Initial commit fixed typo"
[main 705a39e] Initial commit fixed typo (amended)

$ ./kitkat log
commit 705a39e98213a330019ad538c1405598ac83b435
Author: shatrughan mishra <shatrughanm485@gmail.com>
Date:   Thu Jan 01 14:35:05 2026 +0530
    Initial commit fixed typo
```
✅ Commit hash changed from `9277233` to `705a39e`
✅ Message updated successfully
✅ `(amended)` indicator shown

**Test 2: Error Handling - No Commits**
```
$ rm -rf .kitkat
$ ./kitkat init
Initialized empty KitKat repository in ./.kitkat/

$ ./kitkat commit --amend -m "Should fail"
Error: no commits to amend
```
✅ Properly handles the case when no commits exist

**Test 3: Error Handling - Missing `-m` Flag**
```
$ echo "test" > file.txt
$ ./kitkat add file.txt
$ ./kitkat commit -m "First commit"
[main 064761a] First commit
1 file changed, 2 insertions(+), 0 deletions(-)

$ ./kitkat commit --amend
Usage: kitkat commit --amend -m <message>
```
✅ Shows proper usage message when `-m` flag is missing

**Test 4: Multiple Consecutive Amends**
```
$ ./kitkat commit --amend -m "Second amendment"
[main b6d0fff] Second amendment (amended)

$ ./kitkat commit --amend -m "Third amendment"
[main 1c841a5] Third amendment (amended)

$ ./kitkat log
commit 1c841a5db78b6de921a38bfb54edb4b68e321517
Author: shatrughan mishra <shatrughanm485@gmail.com>
Date:   Thu Jan 01 14:57:53 2026 +0530
    Third amendment
commit b6d0fffd47f61f98de33e816e34b41402bef545e
Author: shatrughan mishra <shatrughanm485@gmail.com>
Date:   Thu Jan 01 14:57:53 2026 +0530
    Second amendment
commit 064761a7cd51e8361fde42534f4b44d9ed5657a3
Author: shatrughan mishra <shatrughanm485@gmail.com>
Date:   Thu Jan 01 14:57:53 2026 +0530
    First commit
```
✅ Multiple amends work correctly
✅ Hashes change: `064761a` → `b6d0fff` → `1c841a5`
✅ Original timestamp (14:57:53) preserved across all amends

## Notes
- All commits appear in the log due to KitKat's append-only commit storage architecture
- The branch pointer correctly references the most recent amended commit
- Previous commits become orphaned (not reachable from any branch)
- This behavior is consistent with KitKat's current storage design

## Acceptance Criteria Met
- ✅ `kitkat commit --amend -m "New Message"` updates the last commit message
- ✅ `kitkat log` shows the new message and a new commit hash
- ✅ No file or tree changes occur (preserves same tree hash)
- ✅ Branch pointer updated to new commit
- ✅ Multiple amends work correctly
- ✅ Error handling for edge cases (no commits, missing flags)
- ✅ Original timestamp and author preserved