### PR TITLE
feat: add -n flag to limit log output

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,10 +78,32 @@ var commands = map[string]CommandFunc{
 	},
 	"log": func(args []string) {
 		oneline := false
-		if len(args) > 0 && args[0] == "--oneline" {
-			oneline = true
+		limit := -1
+		i := 0
+		for i < len(args) {
+			switch args[i] {
+			case "--oneline":
+				oneline = true
+				i++
+			case "-n":
+				if i+1 >= len(args) {
+					fmt.Println("Error: -n requires a positive integer argument")
+					return
+				}
+				var n int
+				_, err := fmt.Sscanf(args[i+1], "%d", &n)
+				if err != nil || n <= 0 {
+					fmt.Println("Error: -n requires a positive integer argument")
+					return
+				}
+				limit = n
+				i += 2
+			default:
+				fmt.Printf("Error: unknown flag %s\n", args[i])
+				return
+			}
 		}
-		if err := core.ShowLog(oneline); err != nil {
+		if err := core.ShowLog(oneline, limit); err != nil {
 			fmt.Println("Error:", err)
 		}
 	},

--- a/internal/core/log.go
+++ b/internal/core/log.go
@@ -6,15 +6,20 @@ import (
 	"github.com/LeeFred3042U/kitkat/internal/storage"
 )
 
-// ShowLog prints the commit log. It accepts a boolean to switch to a compact, one-line format.
-func ShowLog(oneline bool) error {
+// ShowLog prints the commit log. It accepts a boolean to switch to a compact, one-line format
+// and an optional limit to restrict the number of commits shown (use -1 for no limit).
+func ShowLog(oneline bool, limit int) error {
 	commits, err := storage.ReadCommits()
 	if err != nil {
 		return err
 	}
 
+	count := 0
 	// Print in reverse chronological order (newest first).
 	for i := len(commits) - 1; i >= 0; i-- {
+		if limit > 0 && count >= limit {
+			break
+		}
 		commit := commits[i]
 		if oneline {
 			fmt.Printf("%s %s\n", commit.ID[:7], commit.Message)
@@ -24,6 +29,7 @@ func ShowLog(oneline bool) error {
 			fmt.Printf("Date:   %s\n", commit.Timestamp.Local().Format("Mon Jan 02 15:04:05 2006 -0700"))
 			fmt.Printf("\n    %s\n\n", commit.Message)
 		}
+		count++
 	}
 	return nil
 }


### PR DESCRIPTION
Implements -n <number> flag for kitkat log command to limit output to the most recent n commits.

Changes:
- Updated cmd/main.go to parse -n flag with validation
- Modified ShowLog in internal/core/log.go to accept limit parameter
- Added error handling for invalid inputs (non-positive, non-numeric)
- Maintains backward compatibility (default shows all commits)
- Works with --oneline flag

Tested with 6 commits, verified limiting works correctly.

# Description
Fixes #11 

# Implementation Details
## Implementation Details

- Argument parsing for the `-n` flag was added in `cmd/main.go` within the `log` command handler.  
  The parser scans the arguments for `-n` and attempts to convert the following value to a positive integer.

- Input validation ensures:
  - `-n` is followed by a value
  - The value is numeric
  - The value is greater than zero  
  If validation fails, a user-friendly error is printed and execution stops.

- The `ShowLog` function in `internal/core/log.go` was updated to accept a `limit int` parameter instead of having a fixed behavior.

- The commit iteration loop now keeps a counter and stops once `count >= limit`, preventing unnecessary traversal and printing when a limit is provided.

- When `-n` is not specified, the limit defaults to `-1`, preserving the original behavior of printing all commits.

- The implementation does not alter commit ordering; it relies on the existing commit traversal order (newest to oldest).

# Verification (Mandatory)
Tested locally with 6 commits:

**<img width="1159" height="636" alt="image" src="https://github.com/user-attachments/assets/cc0767dc-4e48-4b4d-8b87-71c08cfb1c54" />** `kitkat log -n 3`  
**
<img width="846" height="153" alt="image" src="https://github.com/user-attachments/assets/d300abb9-801b-46ff-9d7c-2c08fdd04068" />
** `kitkat log --oneline -n 3`

# Track Selection
- [x] Track 1: Beginner Code
- [ ] Track 2: Visual Documentation
- [ ] Track 3: Intermediate Code

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `go fmt ./...` locally
- [x] I have verified all "Acceptance Criteria" listed in the issue