### PR TITLE
feature: add tag --list command

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -156,6 +156,13 @@ var commands = map[string]CommandFunc{
 		}
 	},
 	"tag": func(args []string) {
+		if len(args) == 1 && (args[0] == "--list" ) {
+			if err := core.PrintTags(); err != nil {
+				fmt.Println("Error:", err)
+			}
+			return
+		}
+
 		if len(args) < 2 {
 			fmt.Println("Usage: kitkat tag <tag-name> <commit-id>")
 			return

--- a/internal/core/tag.go
+++ b/internal/core/tag.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 )
 
 const tagsDir = ".kitkat/refs/tags"
@@ -20,5 +21,46 @@ func CreateTag(tagName, commitID string) error {
 	}
 
 	fmt.Printf("Tag '%s' created for commit %s\n", tagName, commitID)
+	return nil
+}
+
+// ListTags returns all tag names stored in .kitkat/refs/tags
+func ListTags() ([]string, error) {
+
+	if _, err := os.Stat(tagsDir); err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(tagsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var tags []string
+	for _, entry := range entries {
+
+		if entry.IsDir() {
+			continue
+		}
+		tags = append(tags, entry.Name())
+	}
+
+	sort.Strings(tags)
+	return tags, nil
+}
+
+// PrintTags prints all tags, one per line
+func PrintTags() error {
+	tags, err := ListTags()
+	if err != nil {
+		return err
+	}
+
+	for _, tag := range tags {
+		fmt.Println(tag)
+	}
 	return nil
 }


### PR DESCRIPTION
Implements `kitkat tag --list` to display all existing tags stored under `.kitkat/refs/tags`, one per line.

How to test:
1. ./kitkat init
2. ./kitkat tag v1 abc123
3. ./kitkat tag v2 def456
4. ./kitkat tag --list

Proof of work:
![list](https://github.com/user-attachments/assets/1c96f945-38f5-4f98-b458-2584d83c7de1)



Fixes : Implement kitkat config --list #4

