### PR TITLE
Issue #69: Added Discord community link for contributor support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,10 @@ Thank you for your interest in contributing to **kitkat**! We are building an ed
 
 Whether you are a student looking for your first open-source contribution or a systems engineer wanting to solve complex algorithmic challenges, there is a place for you here.
 
+## 💬 Join Our Community
+
+Have questions? Want to discuss ideas or get help? Join our Discord server: **https://discord.gg/x6henXZs**
+
 ## Ways to Contribute
 
 We have organized contributions into three tracks. Please choose one that matches your interest:
@@ -132,7 +136,7 @@ go build -o kitkat ./cmd/main.go
 
 **For code:**
 - Write clean, idiomatic Go code 
-- If you are new to Go, feel free to ask for help in the PR!
+- If you are new to Go, feel free to ask for help in the PR or on our [Discord server](https://discord.gg/x6henXZs)!
 
 **For documentation:**
 - Work as stated in the issue


### PR DESCRIPTION
# Description
Fixes #69

# Implementation Details
- Added Discord server link (https://discord.gg/x6henXZs) to CONTRIBUTING.md
- Placed link at the beginning for maximum visibility
- Helps new contributors join the community and get support

# Verification (Mandatory)
- Verified Discord link works correctly
- Checked markdown formatting
- Confirmed placement is visible and accessible

# Track Selection
- [x] Track 1: Easy (Documentation)
- [ ] Track 2: Medium
- [ ] Track 3: Hard

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `go fmt ./...` locally (not applicable – documentation only)
- [x] I have verified all "Acceptance Criteria" listed in the issue

### Terminal Commands
<img width="683" height="83" alt="Screenshot from 2026-01-03 16-13-08" src="https://github.com/user-attachments/assets/6487139f-6182-4ca0-a4da-0af1c9130d69" />

*Created branch and verified the project builds successfully*
