### PR TITLE
fix: ensure tag command checks for initialized repo

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -302,6 +302,11 @@ var commands = map[string]CommandFunc{
 		}
 	},
 	"tag": func(args []string) {
+		if !core.IsRepoInitialized() {
+			fmt.Println("Error: not a kitkat repository (or any of the parent directories): .kitkat")
+			return
+		}
+
 		if len(args) == 1 && (args[0] == "--list") {
 			if err := core.PrintTags(); err != nil {
 				fmt.Println("Error:", err)

--- a/internal/core/tag.go
+++ b/internal/core/tag.go
@@ -11,6 +11,10 @@ const tagsDir = ".kitkat/refs/tags"
 
 // Creates a new lightweight tag pointing to a specific commit
 func CreateTag(tagName, commitID string) error {
+	if !IsRepoInitialized() {
+		return fmt.Errorf("not a kitkat repository (or any of the parent directories): .kitkat")
+	}
+
 	if err := os.MkdirAll(tagsDir, 0755); err != nil {
 		return err
 	}
@@ -34,6 +38,9 @@ func CreateTag(tagName, commitID string) error {
 
 // ListTags returns all tag names stored in .kitkat/refs/tags
 func ListTags() ([]string, error) {
+	if !IsRepoInitialized() {
+		return nil, fmt.Errorf("not a kitkat repository (or any of the parent directories): .kitkat")
+	}
 
 	if _, err := os.Stat(tagsDir); err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
# Description
Fixes the issue where `kitkat tag` command would display usage instructions instead of an error when run outside of an initialized kitkat repository.
fixes #70

# Implementation Details
- **internal/core/tag.go**: Added `IsRepoInitialized()` checks to `CreateTag` and `ListTags` functions to ensure both fail gracefully when not in a repository.
- **cmd/main.go**: Updated the `tag` command handler to check for repository initialization **before** parsing arguments. This ensures that the "not a kitkat repository" error takes precedence over argument validation errors.

# Verification (Mandatory)
<img width="684" height="149" alt="Screenshot 2026-01-04 164147" src="https://github.com/user-attachments/assets/f9984c84-e8ee-4f14-aaa2-eddb053debcc" />

- Tested `kitkat tag` (with no arguments) outside a repository:
  - **Before**: displayed "Usage: kitkat tag <tag-name> <commit-id>"
  - **After**: displays "Error: not a kitkat repository (or any of the parent directories): .kitkat"
- Tested `kitkat tag v1.0` (missing 2nd argument) outside a repository:
  - **After**: displays "Error: not a kitkat repository (or any of the parent directories): .kitkat"
- Tested `kitkat tag v1.0 abc123` outside a repository:
  - **After**: displays "Error: not a kitkat repository (or any of the parent directories): .kitkat"
- Tested `kitkat tag --list` outside a repository:
  - **After**: displays "Error: not a kitkat repository (or any of the parent directories): .kitkat"

# Track Selection
- [x] Track 1: Beginner Code

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `go fmt ./...` locally
- [x] I have verified all "Acceptance Criteria" listed in the issue
