### PR TITLE
fix: add initialization check to ls-files command

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -260,6 +260,11 @@ var commands = map[string]CommandFunc{
 		}
 	},
 	"ls-files": func(args []string) {
+		if !core.IsRepoInitialized() {
+			fmt.Println("Error: not a kitkat repository (or any of the parent directories): .kitkat")
+			return
+		}
+
 		entries, err := core.LoadIndex()
 		if err != nil {
 			fmt.Println("Error loading index:", err)


### PR DESCRIPTION
# Description
Fixes the issue where `kitkat ls-files` command would display an error or attempt to load the index instead of checking if the repository is initialized first.
fixes #70 

# Implementation Details
- **cmd/main.go (ls-files command)**: Added `IsRepoInitialized()` check at the start of the `ls-files` command handler, before calling `core.LoadIndex()`. This ensures that the "not a kitkat repository" error takes precedence over index loading errors.

# Verification (Mandatory)
- Tested `kitkat ls-files` outside a repository:
  - **Before**: displayed "Error loading index: ..." (or similar)
  - **After**: displays "Error: not a kitkat repository (or any of the parent directories): .kitkat"
- Tested `kitkat ls-files` inside an initialized repository:
  - **Result**: Works correctly, listing tracked files
  
<img width="670" height="100" alt="Screenshot 2026-01-04 170301" src="https://github.com/user-attachments/assets/7094653f-1222-40ab-b756-fa5e8592b612" />


# Track Selection
- [x] Track 1: Beginner Code
- [ ] Track 2: Visual Documentation
- [ ] Track 3: Intermediate Code

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `go fmt ./...` locally
- [x] I have verified all "Acceptance Criteria" listed in the issue
