### PR TITLE
Fix/commit init check ls-files check

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,6 +48,11 @@ var commands = map[string]CommandFunc{
 		fmt.Printf("Removed '%s'\n", filename)
 	},
 	"commit": func(args []string) {
+		if !core.IsRepoInitialized() {
+			fmt.Println("Error: not a kitkat repository (or any of the parent directories): .kitkat")
+			return
+		}
+
 		if len(args) < 1 {
 			fmt.Println("Usage: kitkat commit <-m | -am | --amend> <message>")
 			return
@@ -260,6 +265,11 @@ var commands = map[string]CommandFunc{
 		}
 	},
 	"ls-files": func(args []string) {
+		if !core.IsRepoInitialized() {
+			fmt.Println("Error: not a kitkat repository (or any of the parent directories): .kitkat")
+			return
+		}
+
 		entries, err := core.LoadIndex()
 		if err != nil {
 			fmt.Println("Error loading index:", err)


### PR DESCRIPTION
# Description
Fixes the issue where `kitkat commit` command would display usage instructions or attempt operations instead of checking if the repository is initialized first.
fixes #70

# Implementation Details
- **cmd/main.go (commit command)**: Added `IsRepoInitialized()` check at the start of the `commit` command handler, before argument validation. This ensures that the "not a kitkat repository" error takes precedence over argument and operation errors.
- - **cmd/main.go (ls-files command)**: Added `IsRepoInitialized()` check at the start of the `ls-files` command handler

# Verification (Mandatory)
<img width="719" height="164" alt="Screenshot 2026-01-04 181033" src="https://github.com/user-attachments/assets/89552403-5e8d-45c6-8e4e-21eecaf4bba7" />

<img width="670" height="100" alt="Screenshot 2026-01-04 170301" src="https://github.com/user-attachments/assets/3b078b8a-7015-43f4-b086-0b462de23a3d" />

- Tested `kitkat commit` (no arguments) outside a repository:
  - **Before**: displayed "Usage: kitkat commit <-m | -am | --amend> <message>"
  - **After**: displays "Error: not a kitkat repository (or any of the parent directories): .kitkat"
- Tested `kitkat commit -m "test"` outside a repository:
  - **After**: displays "Error: not a kitkat repository (or any of the parent directories): .kitkat"
- Tested `kitkat commit -am "test"` outside a repository:
  - **After**: displays "Error: not a kitkat repository (or any of the parent directories): .kitkat"
- Tested inside an initialized repository:
  - **Result**: All commit variants work correctly

# Track Selection
- [x] Track 1: Beginner Code
- [ ] Track 2: Visual Documentation
- [ ] Track 3: Intermediate Code

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `go fmt ./...` locally
- [x] I have verified all "Acceptance Criteria" listed in the issue
