### PR TITLE
feat: Implement strict fast-forward merge logic

### DIFF
--- a/internal/core/helpers.go
+++ b/internal/core/helpers.go
@@ -51,7 +51,7 @@ func UpdateWorkspaceAndIndex(commitHash string) error {
 // GetHeadState returns the current branch name or detached HEAD state.
 // Returns the branch name (e.g., "main") if on a branch, or a detached HEAD description.
 func GetHeadState() (string, error) {
-	headData, err := os.ReadFile(".kitkat/HEAD")
+	headData, err := os.ReadFile(HeadPath)
 	if err != nil {
 		return "", err
 	}
@@ -160,7 +160,7 @@ func IsWorkDirDirty() (bool, error) {
 // UpdateBranchPointer updates the current branch pointer or HEAD to point to a specific commit.
 // Handles both branch mode (updates refs/heads/<branch>) and detached HEAD mode (updates HEAD directly).
 func UpdateBranchPointer(commitHash string) error {
-	headData, err := os.ReadFile(".kitkat/HEAD")
+	headData, err := os.ReadFile(HeadPath)
 	if err != nil {
 		return fmt.Errorf("unable to read HEAD file: %w", err)
 	}
@@ -185,16 +185,16 @@ func UpdateBranchPointer(commitHash string) error {
 	}
 
 	// Case B: Detached HEAD (HEAD contains a commit hash directly)
-	if err := os.WriteFile(".kitkat/HEAD", []byte(commitHash), 0644); err != nil {
+	if err := os.WriteFile(HeadPath, []byte(commitHash), 0644); err != nil {
 		return fmt.Errorf("failed to update HEAD: %w", err)
 	}
 	return nil
 }
 
-// readCurrentHeadCommit returns the commit hash that HEAD currently points to.
+// readHead returns the commit hash that HEAD currently points to.
 // This is useful for rollback operations.
-func readCurrentHeadCommit() (string, error) {
-	headData, err := os.ReadFile(".kitkat/HEAD")
+func readHead() (string, error) {
+	headData, err := os.ReadFile(HeadPath)
 	if err != nil {
 		return "", err
 	}
@@ -239,7 +239,7 @@ func IsSafePath(path string) bool {
 // After a reset, HEAD might point to an earlier commit than the last one in the log.
 func GetHeadCommit() (models.Commit, error) {
 	// Get the commit hash that HEAD points to
-	commitHash, err := readCurrentHeadCommit()
+	commitHash, err := readHead()
 	if err != nil {
 		return models.Commit{}, err
 	}

--- a/internal/core/rebase.go
+++ b/internal/core/rebase.go
@@ -65,7 +65,7 @@ func RebaseInteractive(commitHash string) error {
 	if err != nil {
 		return err
 	}
-	headHash, err := readCurrentHeadCommit()
+	headHash, err := readHead()
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func RebaseContinue() error {
 		}
 
 		if cmd == "reword" {
-			head, _ := readCurrentHeadCommit()
+			head, _ := readHead()
 			newMsg := promptForMessage(msg)
 			if newMsg != msg {
 				amendCommitMessage(head, newMsg)
@@ -294,7 +294,7 @@ func RunRebaseLoop() error {
 // finishRebase finalizes the rebase by updating HEAD and cleaning up temporary state
 // returns an error if any operation fails
 func finishRebase(state *RebaseState) error {
-	headHash, err := readCurrentHeadCommit()
+	headHash, err := readHead()
 	if err != nil {
 		return err
 	}

--- a/internal/core/reset.go
+++ b/internal/core/reset.go
@@ -20,7 +20,7 @@ func ResetHard(commitHash string) error {
 	}
 
 	// Step 2: Save current HEAD for potential rollback
-	oldHeadCommit, err := readCurrentHeadCommit()
+	oldHeadCommit, err := readHead()
 	if err != nil {
 		return fmt.Errorf("fatal: unable to read HEAD file: %w", err)
 	}

--- a/internal/storage/commitStore.go
+++ b/internal/storage/commitStore.go
@@ -147,3 +147,38 @@ func IsAncestor(ancestorHash, descendantHash string) (bool, error) {
 	}
 	return false, nil
 }
+
+// FindMergeBase calculates the best common ancestor between two commits.
+// Uses a simple ancestry path intersection (assumes linear/simple branching for now).
+func FindMergeBase(hash1, hash2 string) (string, error) {
+	if hash1 == hash2 {
+		return hash1, nil
+	}
+
+	// Trace ancestry of hash1
+	ancestors1 := make(map[string]bool)
+	current := hash1
+	for current != "" {
+		ancestors1[current] = true
+		c, err := FindCommit(current)
+		if err != nil {
+			return "", err
+		}
+		current = c.Parent
+	}
+
+	// Trace ancestry of hash2 and find first match
+	current = hash2
+	for current != "" {
+		if ancestors1[current] {
+			return current, nil
+		}
+		c, err := FindCommit(current)
+		if err != nil {
+			return "", err
+		}
+		current = c.Parent
+	}
+
+	return "", fmt.Errorf("no common ancestor found")
+}


### PR DESCRIPTION
# Implement Strict Fast-Forward Only Merge
fixes #75

## Summary
This PR implements a strict "Fast-Forward Only" merge policy for `kitkat`. To keep the history linear and simple, `kitkat` will now refuse to merge if the branch history has diverged from the current HEAD. Merge commits ("diamond" shapes) are explicitly not supported.

## Changes

### Core Logic
- **Strict Fast-Forward Policy**: Updated `Merge` in `internal/core/merge.go`.
    - **Safety Check**: Aborts if the working directory is "dirty" (has uncommitted changes) to prevent data loss.
    - **Ancestry Check**: Verifies that the target branch is a direct descendant of the current HEAD.
    - **Abort on Divergence**: If the branches have diverged (i.e., `MergeBase != HEAD`), the merge fails with a descriptive error requiring the user to rebase.
- **Fast-Forward Execution**: Moves the `HEAD` pointer to the target commit and updates the working directory and index.

### Storage Utilities
- **FindMergeBase**: Added `FindMergeBase` in `internal/storage/commitStore.go` to calculate the common ancestor of two commits, enabling the divergence check.
- **IsAncestor**: Added/Updated helper to check commit ancestry.

### Testing
- **New Integration Test**: Added `test/merge_test.go` which verifies:(currently removed it as it was not part of the issue)
    - ✅ **Success**: Merging a branch that is ahead of HEAD (Fast-Forward).
    - ❌ **Failure**: Merging a branch that has diverged (requires rebase).
    - ❌ **Failure**: Merging with a dirty working directory.

## Verification
Ran the new integration test:
```
go test -v ./test/merge_test.go
```
**Output:**
<img width="533" height="227" alt="Screenshot 2026-01-05 202940" src="https://github.com/user-attachments/assets/17d3c114-a77c-4d0f-ace8-13b946300991" />

```
=== RUN   TestMerge
Initialized empty kitkat repository in ./.kitkat/
Updating 026fcde..7090907
Fast-forward
--- PASS: TestMerge (0.43s)
PASS
ok      command-line-arguments  1.447s
```
