### PR TITLE
test: add Myers diff unit tests and fix empty diff bug

### DIFF
--- a/internal/diff/myers.go
+++ b/internal/diff/myers.go
@@ -109,6 +109,9 @@ func (md *MyersDiff[T]) diffMain(text1, text2 []T) []Diff[T] {
 func (md *MyersDiff[T]) diffCompute(text1, text2 []T) []Diff[T] {
 	// If one of the texts is empty, the diff is a simple insertion or deletion.
 	if len(text1) == 0 {
+		if len(text2) == 0 {
+			return []Diff[T]{}
+		}
 		return []Diff[T]{{INSERT, text2}}
 	}
 	if len(text2) == 0 {

--- a/internal/test/diff/myers_test.go
+++ b/internal/test/diff/myers_test.go
@@ -1,0 +1,94 @@
+package diff_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/LeeFred3042U/kitkat/internal/diff"
+)
+
+func TestMyersDiff(t *testing.T) {
+	tests := []struct {
+		name     string
+		text1    []string
+		text2    []string
+		expected []diff.Diff[string]
+	}{
+		{
+			name:     "Empty vs Empty",
+			text1:    []string{},
+			text2:    []string{},
+			expected: nil, // Or empty slice depending on implementation details
+		},
+		{
+			name:  "Insert Only",
+			text1: []string{},
+			text2: []string{"a", "b"},
+			expected: []diff.Diff[string]{
+				{Operation: diff.INSERT, Text: []string{"a", "b"}},
+			},
+		},
+		{
+			name:  "Delete Only",
+			text1: []string{"a", "b"},
+			text2: []string{},
+			expected: []diff.Diff[string]{
+				{Operation: diff.DELETE, Text: []string{"a", "b"}},
+			},
+		},
+		{
+			name:  "Replace",
+			text1: []string{"a"},
+			text2: []string{"b"},
+			expected: []diff.Diff[string]{
+				{Operation: diff.DELETE, Text: []string{"a"}},
+				{Operation: diff.INSERT, Text: []string{"b"}},
+			},
+		},
+		{
+			name:  "Identical",
+			text1: []string{"a", "b"},
+			text2: []string{"a", "b"},
+			expected: []diff.Diff[string]{
+				{Operation: diff.EQUAL, Text: []string{"a", "b"}},
+			},
+		},
+		{
+			name:  "Mixed",
+			text1: []string{"a", "b", "c"},
+			text2: []string{"a", "d", "c"},
+			expected: []diff.Diff[string]{
+				{Operation: diff.EQUAL, Text: []string{"a"}},
+				{Operation: diff.DELETE, Text: []string{"b"}},
+				{Operation: diff.INSERT, Text: []string{"d"}},
+				{Operation: diff.EQUAL, Text: []string{"c"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := diff.NewMyersDiff(tt.text1, tt.text2)
+			got := d.Diffs()
+
+			if len(got) != len(tt.expected) {
+				t.Errorf("Diffs() length = %v, want %v\nGot: %v\nWant: %v", len(got), len(tt.expected), got, tt.expected)
+				return
+			}
+
+			for i := range got {
+				if got[i].Operation != tt.expected[i].Operation {
+					t.Errorf("Diffs()[%d].Operation = %v, want %v", i, got[i].Operation, tt.expected[i].Operation)
+				}
+				if !reflect.DeepEqual(got[i].Text, tt.expected[i].Text) {
+					// Handle nil vs empty slice distinction if helpful, but DeepEqual handles []string{} vs nil as different.
+					// We should probably allow nil/empty mismatch if both are effective empty.
+					if len(got[i].Text) == 0 && len(tt.expected[i].Text) == 0 {
+						continue
+					}
+					t.Errorf("Diffs()[%d].Text = %v, want %v", i, got[i].Text, tt.expected[i].Text)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Pull Request

## 1. PR Type (MANDATORY)

Select **exactly one**.

- [ ] **feat** – New user-facing command, flag, or engine capability
- [ ] **fix** – Bug fix correcting existing behavior
- [x] **test** – Test-only changes (no production code)
- [ ] **chore** – Refactor, docs, tooling, or cleanup (no behavior change)

# PR Description

## Title
test: add Myers diff unit tests and fix empty diff bug

## Description
This PR adds comprehensive unit tests for the Myers diff algorithm implementation in `internal/diff/myers.go`.
It also fixes a bug where comparing two empty slices (or sequences that reduced to empty after removing common prefix/suffix) resulted in an incorrect `INSERT` operation with empty text, instead of an empty diff.

## Changes
- Created `internal/test/diff/myers_test.go` with table-driven tests.
- Fixed `diffCompute` in `internal/diff/myers.go` to handle empty vs empty case correctly.

## Verification
- Ran `go test ./internal/test/diff/...` and all tests passed.

## 8. Issue Linkage

* Related Issue(s): `Fixes #112 



<img width="602" height="343" alt="Screenshot 2026-01-06 003413" src="https://github.com/user-attachments/assets/d04b91cd-8f9f-427b-ae79-9f9bd8e81046" />


## 9. Final Checklist (NO GUESSING)
```
Select **exactly one** formatting option.

* [x] I have run `go fmt ./...` (required for all Go code changes)


Confirm all that apply:

* [x] PR type correctly selected
* [x] Test classification (unit vs integration) is accurate
* [x] No behavior change hidden as chore
* [x] All acceptance criteria in linked issues are met
