### PR TITLE
fix: IsRepoInitialized recursive check and handle empty index

### DIFF
--- a/internal/core/helpers.go
+++ b/internal/core/helpers.go
@@ -248,10 +248,33 @@ func GetHeadCommit() (models.Commit, error) {
 	return storage.FindCommit(commitHash)
 }
 
-// IsRepoInitialized checks if the current directory is a valid kitkat repository.
+// IsRepoInitialized checks if the current directory or any parent is a valid kitkat repository.
+// If found, it changes the current working directory to the repository root.
 func IsRepoInitialized() bool {
-	_, err := os.Stat(RepoDir)
-	return err == nil
+	cwd, err := os.Getwd()
+	if err != nil {
+		return false
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(cwd, RepoDir)); err == nil {
+			// Found the repository root
+			// Update the working directory to the repo root so that
+			// all relative paths (RepoDir, etc.) are valid.
+			if err := os.Chdir(cwd); err != nil {
+				return false
+			}
+			return true
+		}
+
+		parent := filepath.Dir(cwd)
+		if parent == cwd {
+			// Reached the system root without finding .kitkat
+			return false
+		}
+		cwd = parent
+	}
+
 }
 
 // Write data in safe way

--- a/internal/core/index.go
+++ b/internal/core/index.go
@@ -14,12 +14,16 @@ type IndexEntry struct {
 
 // LoadIndex reads the .kitkat/index file
 func LoadIndex() ([]IndexEntry, error) {
-	data, err := os.ReadFile(".kitkat/index")
+	data, err := os.ReadFile(IndexPath)
 	if os.IsNotExist(err) {
 		return []IndexEntry{}, nil
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	if len(data) == 0 {
+		return []IndexEntry{}, nil
 	}
 
 	var entryMap map[string]string
@@ -37,7 +41,7 @@ func LoadIndex() ([]IndexEntry, error) {
 
 // SaveIndex writes the index back to disk
 func SaveIndex(entries []IndexEntry) error {
-	file, err := os.Create(".kitkat/index")
+	file, err := os.Create(IndexPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Fix: IsRepoInitialized Recursive Check & Empty Index Handling

## Description
This PR addresses two issues related to repository initialization and command execution from subdirectories.
fixes #98 

1.  **`IsRepoInitialized` Check**:
    - Previously, `IsRepoInitialized` only checked for the existence of `.kitkat` in the *current* directory.
    - Commands like `ls-files` or `status` failed when run from a subdirectory (e.g., `cmd/`) because they couldn't find `.kitkat`.
    - **Fix**: The function now recursively checks parent directories until it finds the repository root or hits the system root. If found, it changes the working directory to the repository root so that relative paths (like `.kitkat/index`) resolve correctly.

2.  **Corrupted Index on Init**:
    - `kitkat init` creates an empty `.kitkat/index` file.
    - `LoadIndex` previously attempted to `json.Unmarshal` this empty file, resulting in an "index file corrupted" error/panic immediately after initialization.
    - **Fix**: `LoadIndex` now checks if the file is empty and returns an empty entry list instead of erroring.

## Changes
- `internal/core/helpers.go`: Updated `IsRepoInitialized` to recursively search for `.kitkat`.
- `internal/core/index.go`: Added a check for empty file content in `LoadIndex`.

## Verification
- Verified by creating a reproduction script (`repro.bat`) that initializes a repo, creates a subdirectory, and runs `ls-files`.
- Before fix: `ls-files` failed with "not a kitkat repository".
- After fix: `ls-files` runs successfully (returning empty output for a fresh repo).

<img width="849" height="560" alt="Screenshot 2026-01-06 173219" src="https://github.com/user-attachments/assets/76dc2ead-805b-48b7-9494-3534149642bc" />


## Related Issues
- Fixing command execution in subdirectories.
- Fixing "index file corrupted" on fresh init.
