### PR TITLE
feat: implement --allow-empty commit flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,8 +64,14 @@ var commands = map[string]CommandFunc{
 			os.Exit(1)
 		}
 
+		allowEmpty := false
+		if len(args) > 0 && args[0] == "--allow-empty" {
+			allowEmpty = true
+			args = args[1:]
+		}
+
 		if len(args) < 2 {
-			fmt.Println("Usage: kitkat commit <-m | -am | --amend> <message>")
+			fmt.Println("Usage: kitkat commit [--allow-empty] <-m | -am | --amend> <message>")
 			os.Exit(2)
 		}
 
@@ -84,7 +90,7 @@ var commands = map[string]CommandFunc{
 		// Normal commit flow
 		case "-am":
 			message = strings.Join(args[1:], " ")
-			newCommit, summary, err := core.CommitAll(message)
+			newCommit, summary, err := core.CommitAll(message, allowEmpty)
 			if err != nil {
 				if err.Error() == "nothing to commit, working tree clean" {
 					fmt.Println(err.Error())
@@ -97,7 +103,7 @@ var commands = map[string]CommandFunc{
 		case "-m":
 			message = strings.Join(args[1:], " ")
 		default:
-			fmt.Println("Usage: kitkat commit <-m | -am | --amend> <message>")
+			fmt.Println("Usage: kitkat commit [--allow-empty] <-m | -am | --amend> <message>")
 			os.Exit(2)
 		}
 
@@ -117,7 +123,7 @@ var commands = map[string]CommandFunc{
 			fmt.Printf("[%s %s] %s (amended)\n", headState, newCommit.ID[:7], newCommit.Message)
 			os.Exit(0)
 		} else {
-			newCommit, summary, err := core.Commit(message)
+			newCommit, summary, err := core.Commit(message, allowEmpty)
 			if err != nil {
 				if err.Error() == "nothing to commit, working tree clean" {
 					fmt.Println(err.Error())

--- a/internal/core/rebase.go
+++ b/internal/core/rebase.go
@@ -175,7 +175,7 @@ func RebaseContinue() error {
 	switch cmd {
 	case "pick", "reword":
 		msg := originalCommit.Message
-		_, _, err := Commit(msg)
+		_, _, err := Commit(msg, false)
 		if err != nil {
 			if strings.Contains(err.Error(), "nothing to commit") {
 				fmt.Println("Nothing to commit. Skipping step.")
@@ -361,7 +361,7 @@ func cherryPick(hash string, noCommit bool) error {
 	if noCommit {
 		return nil
 	}
-	_, _, err = Commit(commit.Message)
+	_, _, err = Commit(commit.Message, false)
 	if err != nil && strings.Contains(err.Error(), "nothing to commit") {
 		return nil
 	}


### PR DESCRIPTION
# Pull Request

## 1. PR Type (MANDATORY)

Select **exactly one**

* [x] **feat** – New user-facing command, flag, or engine capability
* [ ] **fix** – Bug fix correcting existing behavior
* [ ] **test** – Test-only changes (no production code)
* [ ] **chore** – Refactor, docs, tooling, or cleanup (no behavior change)

# Feature: Implement `--allow-empty` Commit Flag

## Description
fixes #135 
This PR implements the `--allow-empty` flag for the `commit` command in `kitkat`. 
Currently, `kitkat commit` aborts if there are no changes in the working directory (identical tree hash). This change allows users to override this behavior and create empty commits, which is useful for CI/CD triggers, semantic versioning tagging, or checkpointing.

## Changes
- **`cmd/main.go`**: Added parsing for the `--allow-empty` flag in the `commit` command handler.
- **`internal/core/commit.go`**: 
    - Updated `Commit` and `CommitAll` signatures to accept `allowEmpty bool`.
    - Modified validation logic to bypass the "nothing to commit" error if the flag is set.
    - Refactored to use constants `RepoDir` and `HeadPath` from `constants.go`.
- **`internal/core/helpers.go`**:
    - Fixed `SafeWrite` to skip directory synchronization on Windows to prevent "Access is denied" errors.
    - Added `runtime` import.
- **`internal/core/rebase.go`**:
    - Updated calls to `Commit` to pass `false` for `allowEmpty` (preserving default behavior during rebase).

## Verification
<img width="785" height="352" alt="Screenshot 2026-01-08 232126" src="https://github.com/user-attachments/assets/8b2f0305-a122-4b5d-beac-1c26c3589e88" />

- **Manual Tests**:
    - Verified `kitkat commit --allow-empty -m "msg"` creates a commit even with no changes.
    - Verified `kitkat commit -m "msg"` (without flag) still fails if no changes exist.
    - Verified normal commits (with changes) work as expected.
    - Verified `kitkat rebase` still functions correctly.

