### PR TITLE
Workflow/commit count

### DIFF
--- a/.github/workflows/check-commit-count.yml
+++ b/.github/workflows/check-commit-count.yml
@@ -1,0 +1,20 @@
+name: Check Commit Count
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  check-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check commit count
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const commits = context.payload.pull_request.commits;
+            if (commits !== 1) {
+              core.setFailed(`PR has ${commits} commits. Please squash your changes into a single commit.`);
+            } else {
+              console.log("PR has exactly 1 commit.");
+            }


### PR DESCRIPTION
# PR Description: Add Check Commit Count Workflow
fixes #124 

## Summary
This PR introduces a new GitHub Actions workflow, `Check Commit Count`, which enforces a "one commit per PR" policy. This ensures a clean and linear commit history for the repository.

## Changes
- **New Workflow**: `.github/workflows/check-commit-count.yml`
    - Triggered on `pull_request` events (opened, synchronized, reopened, edited).
    - Checks the number of commits in the PR context.
    - Fails if the commit count is not exactly `1`.
    
<img width="1369" height="539" alt="Screenshot 2026-01-09 015025" src="https://github.com/user-attachments/assets/1f5bca37-97e9-47fe-8c33-76dea864a20d" />



## Purpose
To encourage developers to squash their changes into a single atomic commit before merging, simplifying history navigation and reverting if necessary.

## Testing
- **Pass Case**: Create a PR with exactly one commit. The workflow should pass.
- **Fail Case**: Create a PR with more than one commit. The workflow should fail with a message prompting to squash.
