### PR TITLE
feat: add kitcat grep command with tests

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,6 +40,14 @@ var commands = map[string]CommandFunc{
 		}
 		os.Exit(exitCode)
 	},
+	"grep": func(args []string) {
+		if err := core.Grep(args); err != nil {
+			fmt.Println("Error:", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	},
+
 	"rm": func(args []string) {
 		if len(args) < 1 {
 			fmt.Println("Usage: kitcat rm <file>")

--- a/internal/core/grep.go
+++ b/internal/core/grep.go
@@ -1,0 +1,96 @@
+package core
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/LeeFred3042U/kitcat/internal/storage"
+)
+
+/*
+Binary detection using NUL-byte heuristic
+*/
+func isBinary(data []byte) bool {
+	return bytes.Contains(data, []byte{0})
+}
+
+/*
+kitcat grep implementation
+*/
+func Grep(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: kitcat grep [--line-number] <pattern>")
+	}
+
+	showLineNumber := false
+	i := 0
+
+	if args[0] == "--line-number" {
+		showLineNumber = true
+		i++
+	}
+
+	if len(args[i:]) < 1 {
+		return fmt.Errorf("usage: kitcat grep [--line-number] <pattern>")
+	}
+
+	pattern := args[i]
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return err
+	}
+
+	// Load kitcat index (only tracked files)
+	indexMap, err := storage.LoadIndex()
+	if err != nil {
+		return err
+	}
+
+	// Deterministic order: sort file paths
+	paths := make([]string, 0, len(indexMap))
+	for path := range indexMap {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+
+		// Skip binary files
+		if isBinary(data) {
+			continue
+		}
+
+		// Only UTF-8 files are scanned
+		if !utf8.Valid(data) {
+			continue
+		}
+
+		scanner := bufio.NewScanner(strings.NewReader(string(data)))
+		lineNo := 1
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			if re.MatchString(line) {
+				if showLineNumber {
+					fmt.Printf("%s:%d:%s\n", path, lineNo, line)
+				} else {
+					fmt.Printf("%s:%s\n", path, line)
+				}
+			}
+			lineNo++
+		}
+	}
+
+	return nil
+}

--- a/internal/core/grep_test.go
+++ b/internal/core/grep_test.go
@@ -1,0 +1,89 @@
+package core
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/LeeFred3042U/kitcat/internal/storage"
+)
+
+func TestGrepBasic(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Save and restore working directory
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatalf("failed to restore working dir: %v", err)
+		}
+	}()
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create test files
+	mainContent := "package main\n\nfunc main() {}\n"
+	if err := os.WriteFile("main.go", []byte(mainContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile("ignore.go", []byte("func ignored() {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create .kitcat directory
+	if err := os.Mkdir(".kitcat", 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write kitcat index (ONLY tracked files)
+	index := map[string]string{
+		"main.go": "dummyhash",
+	}
+
+	if err := storage.WriteIndex(index); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture stdout
+	var buf bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	// Run grep
+	if err := Grep([]string{"--line-number", "func"}); err != nil {
+		t.Fatalf("grep returned error: %v", err)
+	}
+
+	// Restore stdout
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = oldStdout
+
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	output := buf.String()
+
+	// Assert expected match
+	if !strings.Contains(output, "main.go:3:func main()") {
+		t.Fatalf("expected match not found, got:\n%s", output)
+	}
+
+	// Ensure untracked file is ignored
+	if strings.Contains(output, "ignore.go") {
+		t.Fatalf("untracked file should not be searched")
+	}
+}


### PR DESCRIPTION
## 1. PR Type
- [x] feat
- [ ] fix
- [ ] test
- [ ] chore

## 2. Scope Guard
Allowed:
- internal/core/grep.go
- cmd/main.go
- internal/core/grep_test.go

Not Allowed:
- index format changes
- object storage
- hashing logic

## 3. Description
Introduces a new `kitcat grep` command to search for a regex pattern across
files tracked in the Kitcat index. Files are read from the working tree,
binary files are skipped, and results are printed deterministically in
file:line:content format. Supports an optional --line-number flag.

## 4. Intent Declaration
User-facing change: Yes  
Data format change: No  
Filesystem interaction: Yes (read-only)

## 5. Storage Safety
- Does not write to .kitcat/objects
- Does not modify index format
- Does not change hashing behavior

## 6. Backward Compatibility
No breaking changes for existing repositories.

## 7. Tests
Added integration test validating grep behavior on indexed files only.

## 8. Verification Steps
1. Create a file containing `func main`
2. Run `kitcat add <file>`
3. Run `kitcat grep "func main"`
4. Observe deterministic output in file:line:content format

## 9. Verification Screenshots
<img width="364" height="19" alt="image" src="https://github.com/user-attachments/assets/dead8323-38bb-404e-9814-c061160dea65" />
<img width="481" height="23" alt="image" src="https://github.com/user-attachments/assets/0a4f9be7-2dff-4908-9881-b75835f99d39" />


## 10. Issue
Fixes #26
