### PR TITLE
feat: support stashing unstaged changes

### DIFF
--- a/internal/test/core/stash_test.go
+++ b/internal/test/core/stash_test.go
@@ -534,3 +534,60 @@ func TestStash_NoCommits(t *testing.T) {
 		t.Errorf("Expected 'no commits yet' error, got: %v", err)
 	}
 }
+
+// TestStash_UnstagedChanges integration test for stashing unstaged changes
+func TestStash_UnstagedChanges(t *testing.T) {
+	tmpDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	// 1. Setup: Initialize and commit file.txt v1
+	testFile := "file.txt"
+	if err := os.WriteFile(testFile, []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := core.AddFile(testFile); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := core.Commit("initial commit"); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. Modify: Change content to v2 (unstaged)
+	if err := os.WriteFile(testFile, []byte("v2"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 3. Push: Run stash
+	if err := core.Stash(); err != nil {
+		t.Fatalf("Stash failed: %v", err)
+	}
+
+	// 4. Assert: Working directory is clean (content reverts to v1)
+	content, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "v1" {
+		t.Errorf("File should be reset to v1 after stash, got: %s", string(content))
+	}
+
+	// 5. Pop: Run stash pop
+	if err := core.StashPop(); err != nil {
+		t.Fatalf("StashPop failed: %v", err)
+	}
+
+	// 6. Assert: Working directory contains v2
+	content, err = os.ReadFile(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "v2" {
+		t.Errorf("File should be restored to v2 after pop, got: %s", string(content))
+	}
+
+	// 7. Verification: Ensure stash reference is gone
+	stashRefPath := filepath.Join(tmpDir, ".kitcat", "refs", "stash")
+	if _, err := os.Stat(stashRefPath); !os.IsNotExist(err) {
+		t.Error("Stash reference should be deleted after pop")
+	}
+}


### PR DESCRIPTION
# Feature: Stash Unstaged Changes
fixes #153 
## Description
This PR implements support for stashing unstaged changes in `kitcat`. Previously, `stash` only captured the state of the Index (staged changes), causing modifications to tracked files in the working directory to be lost upon the subsequent `reset`.

## Changes
- **Modified `internal/core/stash.go`**:
    - Updated `Stash()` to load the current index.
    - Iterates through tracked files to check for on-disk modifications.
    - Hashes and stores modified file contents into the object database.
    - Updates the index map in memory and persists it to disk before creating the tree.
    - This ensures `CreateTree` captures the full state of the working directory (both staged and unstaged changes for tracked files).

- **Modified `internal/test/core/stash_test.go`**:
    - Added `TestStash_UnstagedChanges` integration test.
    - Verifies the full cycle:
        1. Commit a file.
        2. Modify it without staging.
        3. `kitcat stash`.
        4. Verify working directory is clean (reverted to commit).
        5. `kitcat stash pop`.
        6. Verify unstaged changes are restored.

## Verification
- Ran the new integration test: `go test ./internal/test/core
 -run TestStash_UnstagedChanges -v` (PASSED)
- Ran all stash tests: `go test ./internal/test/core -run TestStash -v` (PASSED)
<img width="887" height="258" alt="Screenshot 2026-01-11 134222" src="https://github.com/user-attachments/assets/f8c488fe-606c-4129-8346-b5b2ae9df840" />


