### PR TITLE
fix: recursive directory cleanup in clean

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -304,6 +304,7 @@ var commands = map[string]CommandFunc{
 		os.Exit(0)
 	},
 	"clean": func(args []string) {
+		dryRun := false
 		force := false
 		includeIgnored := false
 
@@ -311,6 +312,9 @@ var commands = map[string]CommandFunc{
 			switch arg {
 			case "-f":
 				force = true
+			case "-fd":
+				force = true
+				dryRun = true
 			case "-x":
 				includeIgnored = true
 			}
@@ -321,7 +325,7 @@ var commands = map[string]CommandFunc{
 			os.Exit(0)
 		}
 
-		if err := core.Clean(true, includeIgnored); err != nil {
+		if err := core.Clean(dryRun, includeIgnored); err != nil {
 			fmt.Println("Error:", err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
# Pull Request

## Type
- [x] **fix** (Bug fix)

## Description
- No empty directories are left behind.
- Better dry run support with `-fd` flag.

## Proof of Work (REQUIRED)
<img width="702" height="633" alt="2026-01-14_01-45" src="https://github.com/user-attachments/assets/1853c62d-913a-4e81-bc56-15eebeba70be" />


## Related Issue
Fixes #158 

## Checklist
- [x] I have run `go fmt ./...` locally
- [x] My PR contains **exactly one commit** (squashed)
- [x] I have added/updated tests for this change
- [x] I have verified that `kitcat` behavior matches Git (if applicable)