### PR TITLE
Support local vs global config

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -17,14 +17,15 @@ func getConfigPath() (string, error) {
 	return filepath.Join(homeDir, ".kitcatconfig"), nil
 }
 
-// readConfig loads the config file into a map
-func readConfig() (map[string]string, error) {
-	config := make(map[string]string)
-	path, err := getConfigPath()
-	if err != nil {
-		return nil, err
-	}
+// getLocalConfigPath returns the absolute path to the local repository config file
+func getLocalConfigPath() (string, error) {
+	localConfigPath := filepath.Join(RepoDir, ".kitcat", "config")
+	return localConfigPath, nil
+}
 
+// readConfigFromPath loads a config file from a specific path into a map
+func readConfigFromPath(path string) (map[string]string, error) {
+	config := make(map[string]string)
 	file, err := os.Open(path)
 	// It's okay if the file doesn't exist yet, just return an empty map
 	if os.IsNotExist(err) {
@@ -47,9 +48,40 @@ func readConfig() (map[string]string, error) {
 	return config, scanner.Err()
 }
 
-// SetConfig sets a key-value pair in the global config file
-func SetConfig(key, value string) error {
-	config, err := readConfig()
+// readConfig loads the global config file into a map
+func readConfig() (map[string]string, error) {
+	path, err := getConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	return readConfigFromPath(path)
+}
+
+// SetConfig sets a key-value pair in the config file (local or global)
+func SetConfig(key, value string, global bool) error {
+	var path string
+
+	if global {
+		// Write to global config
+		globalPath, err := getConfigPath()
+		if err != nil {
+			return err
+		}
+		path = globalPath
+	} else {
+		// Write to local config
+		localConfigPath, err := getLocalConfigPath()
+		if err != nil {
+			return err
+		}
+		path = localConfigPath
+		// Ensure directory exists before writing
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return err
+		}
+	}
+
+	config, err := readConfigFromPath(path)
 	if err != nil {
 		return fmt.Errorf("could not read existing config: %w", err)
 	}
@@ -58,11 +90,6 @@ func SetConfig(key, value string) error {
 	config[key] = value
 
 	// Write the entire updated map back to the file
-	path, err := getConfigPath()
-	if err != nil {
-		return err
-	}
-
 	file, err := os.Create(path)
 	if err != nil {
 		return err
@@ -78,14 +105,42 @@ func SetConfig(key, value string) error {
 	return nil
 }
 
-// GetConfig reads a key from the global config file
-func GetConfig(key string) (string, bool, error) {
-	config, err := readConfig()
+// readKey reads a specific key from a config file at the given path
+// Returns (value, true, nil) if found
+// Returns ("", false, nil) if not found or file doesn't exist
+// Returns error only on real I/O failure
+func readKey(path, key string) (string, bool, error) {
+	config, err := readConfigFromPath(path)
 	if err != nil {
+		// Missing file is not an error
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
 		return "", false, err
 	}
 	value, ok := config[key]
 	return value, ok, nil
+}
+
+// GetConfig reads a key from the config file (local first, then global)
+func GetConfig(key string) (string, bool, error) {
+	// 1. Try local config first
+	localPath, err := getLocalConfigPath()
+	if err != nil {
+		return "", false, err
+	}
+	if value, found, err := readKey(localPath, key); err != nil {
+		return "", false, err
+	} else if found {
+		return value, true, nil
+	}
+
+	// 2. Fallback to global config
+	globalPath, err := getConfigPath()
+	if err != nil {
+		return "", false, err
+	}
+	return readKey(globalPath, key)
 }
 
 // PrintAllConfig prints all key-value pairs in the config file

--- a/internal/test/core/stash_test.go
+++ b/internal/test/core/stash_test.go
@@ -34,10 +34,10 @@ func setupTestRepo(t *testing.T) (string, func()) {
 	}
 
 	// Set up git config for commits
-	if err := core.SetConfig("user.name", "Test User"); err != nil {
+	if err := core.SetConfig("user.name", "Test User", false); err != nil {
 		t.Fatal(err)
 	}
-	if err := core.SetConfig("user.email", "test@example.com"); err != nil {
+	if err := core.SetConfig("user.email", "test@example.com", false); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Fixes #165

## What changed
- Added repository-specific configuration support at `.kitcat/config`
- Removed mandatory enforcement of the `--global` flag
- Local configuration now correctly overrides global configuration

## Proof of Work
<img width="852" height="134" alt="image" src="https://github.com/user-attachments/assets/62ca14bd-c4d1-47d0-b209-35c99d572835" />
