### PR TITLE
testutil: add shared SetupTestRepo helper

### DIFF
--- a/internal/testutil/setup.go
+++ b/internal/testutil/setup.go
@@ -1,0 +1,75 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// SetupTestRepo creates a temporary kitcat repository for tests.
+// It returns the path to the repository root and a cleanup function.
+func SetupTestRepo(t *testing.T) (string, func()) {
+	t.Helper()
+
+	// Save current working directory
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+
+	// Create temp repo
+	repoDir := t.TempDir()
+
+	// Switch to temp repo
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatalf("failed to change directory to temp repo: %v", err)
+	}
+
+	kitcatDir := filepath.Join(repoDir, ".kitcat")
+
+	// Create .kitcat directory
+	if err := os.MkdirAll(kitcatDir, 0o755); err != nil {
+		t.Fatalf("failed to create .kitcat dir: %v", err)
+	}
+
+	// Create required subdirectories
+	dirs := []string{
+		"objects",
+		filepath.Join("refs", "heads"),
+		filepath.Join("refs", "tags"),
+	}
+
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(kitcatDir, d), 0o755); err != nil {
+			t.Fatalf("failed to create %s dir: %v", d, err)
+		}
+	}
+
+	// Create empty files required by storage functions
+	files := []string{
+		"index",
+		"commits.log",
+		filepath.Join("refs", "heads", "main"),
+	}
+
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(kitcatDir, f), []byte{}, 0o644); err != nil {
+			t.Fatalf("failed to create %s: %v", f, err)
+		}
+	}
+
+	// Create HEAD file
+	headPath := filepath.Join(kitcatDir, "HEAD")
+	if err := os.WriteFile(headPath, []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatalf("failed to create HEAD file: %v", err)
+	}
+
+	// Cleanup function
+	cleanup := func() {
+		if err := os.Chdir(originalDir); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}
+
+	return repoDir, cleanup
+}


### PR DESCRIPTION
## Type
- [ ] feat
- [ ] fix
- [x] test
- [x] chore

## Description
Refactors duplicated test repository setup logic into a shared helper
located in `internal/testutil/SetupTestRepo`, improving maintainability
and removing repeated setup code across tests.

## Proof of Work
- Added shared test helper in `internal/testutil`
- Refactored affected tests to use the helper
- Ran `go fmt ./...`
- Verified all tests pass with `go test ./...`
<img width="663" height="171" alt="image" src="https://github.com/user-attachments/assets/4ebc1a45-9ca9-4a53-a064-f58bc1b98053" />



## Related Issue
Fixes #187

## Checklist
- [x] I have run `go fmt ./...` locally
- [x] My PR contains exactly one commit (squashed)
- [x] I have added/updated tests for this change
- [x] I have verified that kitcat behavior matches Git (if applicable)
