### PR TITLE
feat: implement exclusive locking for AppendCommit

### DIFF
--- a/internal/storage/commitStore.go
+++ b/internal/storage/commitStore.go
@@ -21,17 +21,16 @@ func AppendCommit(commit models.Commit) error {
 		return err
 	}
 
-	// Use the generic lock function from lock*.go for consistency
-	lockFile, err := lock(commitsPath)
-	if err != nil {
-		return err
-	}
-	defer unlock(lockFile)
-
 	f, err := os.OpenFile(commitsPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
 	}
+	// Direct locking on the file descriptor
+	if err := LockFile(f); err != nil {
+		f.Close()
+		return err
+	}
+	// Defer close to unlock
 	defer f.Close()
 
 	enc := json.NewEncoder(f)

--- a/internal/storage/lockOther.go
+++ b/internal/storage/lockOther.go
@@ -13,6 +13,11 @@ func lock(path string) (*os.File, error) {
 	return f, nil
 }
 
+// LockFile is a no-op on non-Unix systems (unless we add valid windows locking later)
+func LockFile(f *os.File) error {
+	return nil
+}
+
 func unlock(f *os.File) {
 	f.Close()
 }

--- a/internal/storage/lockUnix.go
+++ b/internal/storage/lockUnix.go
@@ -14,11 +14,16 @@ func lock(path string) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+	if err := LockFile(f); err != nil {
 		f.Close()
 		return nil, err
 	}
 	return f, nil
+}
+
+// LockFile applies an exclusive lock on the file descriptor
+func LockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
 }
 
 // unlock releases the file lock on Unix systems

--- a/scripts/test_concurrent_writes.sh
+++ b/scripts/test_concurrent_writes.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -e
+
+# Setup
+PROJECT_ROOT=$(pwd)
+COMMITS_LOG=".kitcat/commits.log"
+mkdir -p .kitcat
+rm -f "$COMMITS_LOG"
+
+echo "Starting concurrent write test..."
+
+
+
+cat > internal/storage/concurrent_test_runner_test.go <<EOF
+package storage_test
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeeFred3042U/kitcat/internal/models"
+	"github.com/LeeFred3042U/kitcat/internal/storage"
+)
+
+func TestConcurrentAppend(t *testing.T) {
+	// Clean up previous runs regardless of where verify script ran
+	_ = os.RemoveAll(".kitcat")
+	
+	commitsCount := 50
+	var wg sync.WaitGroup
+	wg.Add(commitsCount)
+
+	for i := 0; i < commitsCount; i++ {
+		go func(id int) {
+			defer wg.Done()
+			commit := models.Commit{
+				ID:      fmt.Sprintf("commit-%d", id),
+				Message: fmt.Sprintf("Message %d", id),
+				AuthorName:  "Tester",
+				Timestamp:   time.Now(),
+			}
+			if err := storage.AppendCommit(commit); err != nil {
+				t.Errorf("Failed to append: %v", err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify
+	commits, err := storage.ReadCommits()
+	if err != nil {
+		t.Fatalf("Failed to read commits: %v", err)
+	}
+	if len(commits) != commitsCount {
+		t.Errorf("Expected %d commits, got %d", commitsCount, len(commits))
+	}
+}
+EOF
+
+echo "Running Go concurrent test..."
+go test ./internal/storage -v -run TestConcurrentAppend
+TEST_EXIT_CODE=$?
+
+rm internal/storage/concurrent_test_runner_test.go
+
+if [ $TEST_EXIT_CODE -eq 0 ]; then
+    echo "Stress test PASSED"
+else
+    echo "Stress test FAILED"
+    exit 1
+fi


### PR DESCRIPTION
### Description
Implemented exclusive file locking for `AppendCommit` to correctly handle concurrent commits.

closes #210 

### Changes
- **internal/storage/lockUnix.go**: Added `LockFile(f *os.File)` using `syscall.Flock` with `LOCK_EX`.
- **internal/storage/lockOther.go**: Added no-op `LockFile` implementation for Windows compatibility.
- **internal/storage/commitStore.go**: Updated `AppendCommit` to use direct file locking on the log file descriptor instead of a separate lock file.
- **scripts/test_concurrent_writes.sh**: Added a stress test script (embedded Go test) to verify concurrent appending works without corruption.

### Verification
- Ran `scripts/test_concurrent_writes.sh` which simulated 50 concurrent commits.
- Validated that 50 commits were successfully written and readable.
<img width="625" height="182" alt="Screenshot 2026-01-18 145342" src="https://github.com/user-attachments/assets/a1efcb5f-ff88-4296-8477-b42cf3b5afae" />

