### PR TITLE
feat: Add Stash clear command to remove all stash entries

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -610,6 +610,15 @@ var commands = map[string]CommandFunc{
 			os.Exit(0)
 		}
 
+		if len(args) > 0 && args[0] == "clear" {
+			if err := core.StashClear(); err != nil {
+				fmt.Println("Error:", err)
+				os.Exit(1)
+			}
+			fmt.Println("Cleared all stash entries")
+			os.Exit(0)
+		}
+
 		// Default: stash save
 		if err := core.Stash(); err != nil {
 			fmt.Println("Error:", err)

--- a/internal/core/stash.go
+++ b/internal/core/stash.go
@@ -210,3 +210,17 @@ func StashList() error {
 
 	return nil
 }
+
+// StashClear removes all stash entries from the stash stack.
+// It truncates the stash file to size 0, effectively clearing all stashed changes.
+func StashClear() error {
+	if !IsRepoInitialized() {
+		return fmt.Errorf("fatal: not a kitcat repository (or any of the parent directories): .kitcat")
+	}
+
+	if err := storage.ClearStash(); err != nil {
+		return fmt.Errorf("failed to clear stash: %w", err)
+	}
+
+	return nil
+}

--- a/internal/storage/stash_store.go
+++ b/internal/storage/stash_store.go
@@ -143,3 +143,21 @@ func ListStashes() ([]string, error) {
 
 	return stashes, nil
 }
+
+// ClearStash removes all stash entries by truncating the stash file to size 0.
+func ClearStash() error {
+	// If the file doesn't exist, nothing to clear
+	if _, err := os.Stat(stashPath); os.IsNotExist(err) {
+		return nil
+	}
+
+	// Lock the file to prevent concurrent writes
+	lockFile, err := lock(stashPath)
+	if err != nil {
+		return err
+	}
+	defer unlock(lockFile)
+
+	// Truncate the file to size 0
+	return os.Truncate(stashPath, 0)
+}


### PR DESCRIPTION
## Summary 
This pull request adds a new feature to clear all stash entries in the repository. The main changes include implementing the stash clear functionality in the core logic, updating the storage layer to support file truncation, and wiring up the new command in the CLI.

## Changes

**New stash clear functionality:**

* Added a `StashClear` function in `internal/core/stash.go` to handle clearing all stash entries, including repo initialization checks and error handling.
* Implemented a `ClearStash` function in `internal/storage/stash_store.go` that safely truncates the stash file to remove all entries, including file locking for concurrency safety.

**CLI integration:**

* Updated `cmd/main.go` to add support for the `stash clear` command, which invokes the new core logic and provides appropriate user feedback on success or failure.# Pull Request

## Type
- [x] **feat** (New capability)
- [ ] **fix** (Bug fix)
- [ ] **test** (Test-only changes)
- [ ] **chore** (Refactor, docs, or cleanup)

## ScreenShots
<img width="1353" height="842" alt="image" src="https://github.com/user-attachments/assets/a63cc9ed-55af-4132-8f16-606a2c533c0b" />

## Related Issue
Fixes #213 
