### PR TITLE
fix: make 'kitcat branch' list branches by default

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -503,8 +503,11 @@ var commands = map[string]CommandFunc{
 	},
 	"branch": func(args []string) {
 		if len(args) == 0 {
-			fmt.Println("Usage: kitcat branch [-l | -r <branch-name> | -d <branch-name>]")
-			os.Exit(2)
+			if err := core.ListBranches(); err != nil {
+				fmt.Fprintln(os.Stderr, "Error:", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
 		}
 		switch args[0] {
 		case "-l":


### PR DESCRIPTION
# Fix: Make `kitcat branch` List Branches by Default
closes #218

## Summary

This PR changes the default behavior of `kitcat branch` when run without arguments. Instead of showing a usage error and exiting with code 2, it now lists all available branches, matching standard Git convention.

## Solution

Modified the `branch` command handler in `cmd/main.go` to:
- Call `core.ListBranches()` when `len(args) == 0`
- Exit with code 0 on success
- Exit with code 1 on error (printing error to stderr)

## Changes Made

### Modified Files
- **cmd/main.go**: Updated the `branch` command handler (lines 505-510)


<img width="523" height="82" alt="Screenshot 2026-01-25 181328" src="https://github.com/user-attachments/assets/e1fe8756-dd55-490a-ad6e-82fcce72c24f" />


## Testing

✅ **Build**: Successfully compiled without errors  
✅ **Functionality**: `kitcat branch` now lists branches  
✅ **Consistency**: Output matches `kitcat branch -l` exactly  
✅ **Exit Codes**: Returns 0 on success, 1 on error  
✅ **Backward Compatibility**: All existing flags (`-l`, `-r`, `-d`) work unchanged
