### PR TITLE
Reject path args in diff command

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -182,9 +182,13 @@ var commands = map[string]CommandFunc{
 	},
 	"diff": func(args []string) {
 		staged := false
-		if len(args) > 0 {
-			if args[0] == "--cached" || args[0] == "--staged" {
+		for _, arg := range args {
+			switch arg {
+			case "--cached", "--staged":
 				staged = true
+			default:
+				fmt.Println("Path filtering not supported")
+				os.Exit(2)
 			}
 		}
 		if err := core.Diff(staged); err != nil {


### PR DESCRIPTION
## Summary
- validate diff args and reject unsupported path inputs
- keep `--cached`/`--staged` flags working to toggle staged diff
- exit with code 2 and message "Path filtering not supported" when paths are provided

## Rationale
- issue #226 requests failing early instead of silently ignoring filenames for `kitcat diff <path>`

## Testing
```
go test ./...
# in repo root
$ go run ./cmd/main.go diff main.go
Path filtering not supported
exit status 2
```

Fixes #226