### PR TITLE
fix(cli): restrict init command to accept no arguments

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,6 +13,7 @@ type CommandFunc func(args []string)
 
 var commands = map[string]CommandFunc{
 	"init": func(args []string) {
+		core.EnsureArgs(args, 0, 0, "init")
 		if err := core.InitRepo(); err != nil {
 			fmt.Println("Error:", err)
 			os.Exit(1)

--- a/internal/core/helpers.go
+++ b/internal/core/helpers.go
@@ -328,3 +328,39 @@ func SafeWrite(filename string, data []byte, perm os.FileMode) error {
 	// On Windows, syncing a directory causes "Access is denied" error
 	return syncDir(dirPath)
 }
+
+// EnsureArgs validates that the number of arguments is within [min, max].
+// passing max = -1 means no upper limit.
+// commandName is used for error messages.
+func EnsureArgs(args []string, min, max int, commandName string) {
+	if min < 0 {
+		panic(fmt.Sprintf("EnsureArgs: min arguments must be non-negative, got %d", min))
+	}
+	if max != -1 {
+		if max < 0 {
+			panic(fmt.Sprintf("EnsureArgs: max arguments must be non-negative (or -1 for no limit), got %d", max))
+		}
+		if max < min {
+			panic(fmt.Sprintf("EnsureArgs: max arguments (%d) cannot be less than min arguments (%d)", max, min))
+		}
+	}
+
+	count := len(args)
+	if count < min {
+		if min == 1 {
+			fmt.Printf("Error: %s command requires at least 1 argument\n", commandName)
+		} else {
+			fmt.Printf("Error: %s command requires at least %d arguments\n", commandName, min)
+		}
+		os.Exit(2)
+	}
+
+	if max != -1 && count > max {
+		if max == 0 {
+			fmt.Printf("Error: %s command does not accept arguments\n", commandName)
+		} else {
+			fmt.Printf("Error: %s command accepts at most %d arguments\n", commandName, max)
+		}
+		os.Exit(2)
+	}
+}

--- a/internal/storage/lockOther.go
+++ b/internal/storage/lockOther.go
@@ -13,7 +13,7 @@ import (
 // of the lock file as the lock itself.
 func lock(path string) (*os.File, error) {
 	lockFile := path + ".lock"
-	
+
 	timeout := time.After(5 * time.Second)
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
@@ -24,7 +24,7 @@ func lock(path string) (*os.File, error) {
 		if err == nil {
 			return f, nil
 		}
-		
+
 		if !os.IsExist(err) {
 			return nil, fmt.Errorf("failed to acquire lock: %w", err)
 		}


### PR DESCRIPTION
# Fix: Restrict `init` command to accept no arguments

## Description
The `init` command previously accepted arguments but silently ignored them, leading to user confusion (e.g., `kitcat init foo` would initialize in the current directory instead of `foo`). 

This PR adds a guard clause to the `init` command handler to explicitly reject any arguments with an error message and exit code 2.
closes #221

## Changes
- Modified `cmd/main.go` to check `len(args) > 0` in the `init` handler.
- If arguments are present, it now prints `Error: init command does not accept arguments` and exits with code 2.

## Verification
- Validated that `kitcat init` still works as expected.
- Validated that `kitcat init foo` now fails with the expected error message and does not initialize a repo in the current directory.
<img width="722" height="347" alt="Screenshot 2026-01-26 162858" src="https://github.com/user-attachments/assets/805920ca-f876-4043-aa05-3f334085a577" />
