### PR TITLE
feat: support multiple arguments in rm command

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,16 +50,20 @@ var commands = map[string]CommandFunc{
 
 	"rm": func(args []string) {
 		if len(args) < 1 {
-			fmt.Println("Usage: kitcat rm <file>")
+			fmt.Println("Usage: kitcat rm <file> [file...]")
 			os.Exit(2)
 		}
-		filename := args[0]
-		if err := core.RemoveFile(filename); err != nil {
-			fmt.Println("Error:", err)
-			os.Exit(1)
+
+		exitCode := 0
+		for _, filename := range args {
+			if err := core.RemoveFile(filename); err != nil {
+				fmt.Printf("Error removing '%s': %v\n", filename, err)
+				exitCode = 1
+			} else {
+				fmt.Printf("Removed '%s'\n", filename)
+			}
 		}
-		fmt.Printf("Removed '%s'\n", filename)
-		os.Exit(0)
+		os.Exit(exitCode)
 	},
 	"commit": func(args []string) {
 		if !core.IsRepoInitialized() {


### PR DESCRIPTION
# Description
This PR implements support for multiple arguments in the `rm` command. Previously, `kitcat rm` only processed the first argument and ignored the rest. This change iterates over all provided arguments and attempts to remove each file, reporting individual errors if any occur.
closes #225 

## Changes
- Modified `cmd/main.go` in the `rm` command handler:
    - Replaced single-file processing with a loop over `args`.
    - Added logic to accumulate exit codes (exit with 1 if any file fails, but process all files).
    - Updated success/error messages.

## Verification
- Validated manually using `kitcat rm file1.txt file2.txt`.
- Verified that both files are removed and appropriate messages are displayed.
- Verified that if one file is missing, it reports an error for that file but continues to remove other valid files.

<img width="566" height="201" alt="Screenshot 2026-01-26 164424" src="https://github.com/user-attachments/assets/883e4713-0ef9-46ce-8a3b-b11981cae274" />
