### PR TITLE
fix: reset parsing rejects extra args and preserves mode

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -327,7 +327,7 @@ var commands = map[string]CommandFunc{
 		os.Exit(0)
 	},
 	"reset": func(args []string) {
-		if len(args) < 2 {
+		if len(args) < 1 {
 			fmt.Println("Usage: kitkat reset [--soft | --mixed | --hard] <commit-hash>")
 			os.Exit(2)
 		}
@@ -335,40 +335,32 @@ var commands = map[string]CommandFunc{
 		mode := ""
 		commitHash := ""
 
-		// Helper function to safely get next argument
-		safeNext := func(i int) string {
-			if i+1 < len(args) {
-				return args[i+1]
-			}
-			return ""
-		}
-
 		i := 0
 		for i < len(args) {
 			switch args[i] {
 			case "--" + core.ResetSoft:
 				mode = core.ResetSoft
-				commitHash = safeNext(i)
-				i += 2 // Skip current and next arg
+				i++
 			case "--" + core.ResetMixed:
 				mode = core.ResetMixed
-				commitHash = safeNext(i)
-				i += 2 // Skip current and next arg
+				i++
 			case "--" + core.ResetHard:
 				mode = core.ResetHard
-				commitHash = safeNext(i)
-				i += 2 // Skip current and next arg
+				i++
 			default:
+				// Default: commit hash positional argument.
+				// Reject extra args and do not overwrite previously parsed state.
+				if commitHash != "" {
+					fmt.Println("Error: too many arguments")
+					os.Exit(2)
+				}
+
 				commitHash = args[i]
-				mode = core.ResetMixed
+				if mode == "" {
+					mode = core.ResetMixed
+				}
 				i++
 			}
-		}
-
-		if mode == "" {
-			fmt.Println("Error: must specify --soft, --mixed, or --hard")
-			fmt.Println("Usage: kitkat reset [--soft | --mixed | --hard] <commit-hash>")
-			os.Exit(2)
 		}
 
 		if commitHash == "" {

--- a/cmd/reset_exitcode_test.go
+++ b/cmd/reset_exitcode_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func buildKitcatBinary(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	binName := "kitcat"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	binPath := filepath.Join(tmpDir, binName)
+
+	buildCmd := exec.Command("go", "build", "-o", binPath, "main.go")
+	if output, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("Failed to build kitcat binary: %v\nOutput: %s", err, output)
+	}
+
+	return binPath
+}
+
+func TestResetTooManyArgumentsExitCode(t *testing.T) {
+	binPath := buildKitcatBinary(t)
+
+	cmd := exec.Command(binPath, "reset", "--hard", "HEAD", "extra")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("Expected non-zero exit code, got 0. Output: %s", output)
+	}
+
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("Expected ExitError, got %T: %v", err, err)
+	}
+
+	if code := exitErr.ExitCode(); code != 2 {
+		t.Fatalf("Expected exit code 2, got %d. Output: %s", code, output)
+	}
+
+	if !strings.Contains(string(output), "Error: too many arguments") {
+		t.Fatalf("Expected error message 'Error: too many arguments'. Output: %s", output)
+	}
+}
+
+func TestResetNoArgsShowsUsageExitCode(t *testing.T) {
+	binPath := buildKitcatBinary(t)
+
+	cmd := exec.Command(binPath, "reset")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("Expected non-zero exit code, got 0. Output: %s", output)
+	}
+
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("Expected ExitError, got %T: %v", err, err)
+	}
+
+	if code := exitErr.ExitCode(); code != 2 {
+		t.Fatalf("Expected exit code 2, got %d. Output: %s", code, output)
+	}
+
+	if !strings.Contains(string(output), "Usage: kitkat reset") {
+		t.Fatalf("Expected usage message. Output: %s", output)
+	}
+}


### PR DESCRIPTION
Fixes #243

## Problem
`kitcat reset` argument parsing can overwrite previously parsed state. For example:

- `kitcat reset --hard HEAD extra`

Currently ends up treating `extra` as the commit hash and silently reverting the mode back to `Mixed`, ignoring `--hard` and `HEAD`.

## Fix
- Parse flags and the positional commit hash without overwriting previously set values.
- Reject extra positional arguments with:
  
  `Error: too many arguments`
  
  and exit code `2`.
- Only default to `Mixed` when no mode flag has been provided.

## Tests
Added CLI-level tests (build the binary and assert exit code/output):
- `reset --hard HEAD extra` exits `2` and prints `Error: too many arguments`
- `reset` (no args) exits `2` and prints usage

## Terminal output (per issue request)
```bash
$ ./kitcat reset --hard HEAD extra
Error: too many arguments
$ echo $?
2
```
