### PR TITLE
Fix rm to remove multiple files

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,7 +56,7 @@ var commands = map[string]CommandFunc{
 		}
 
 		recursive := false
-		filename := ""
+		filesToRemove := []string{}
 
 		i := 0
 		for i < len(args) {
@@ -65,20 +65,24 @@ var commands = map[string]CommandFunc{
 				recursive = true
 				i++
 			default:
-				filename = args[i]
+				filesToRemove = append(filesToRemove, args[i])
 				i++
 			}
 		}
 
-		if filename == "" {
+		if len(filesToRemove) == 0 {
 			fmt.Println("Usage: kitcat rm [-r] <file>")
 			os.Exit(2)
 		}
 
-		if err := core.RemoveFile(filename, recursive); err != nil {
-			fmt.Println("Error:", err)
-			os.Exit(1)
+		exitCode := 0
+		for _, filename := range filesToRemove {
+			if err := core.RemoveFile(filename, recursive); err != nil {
+				fmt.Println("Error:", err)
+				exitCode = 1
+			}
 		}
+		os.Exit(exitCode)
 	},
 	"commit": func(args []string) {
 		if !core.IsRepoInitialized() {


### PR DESCRIPTION
Fixes #244

## Type
- [ ] **feat** (New capability)
- [x] **fix** (Bug fix)
- [ ] **test** (Test-only changes)
- [ ] **chore** (Refactor, docs, or cleanup)

## Description
Fixed the `rm` command to properly handle multiple file arguments. Previously, the command only processed the last file provided due to variable overwriting in the argument parsing loop. Now it accumulates all non-flag arguments into a slice and attempts removal for each file.

**Changes:**
- Refactored argument parsing to use `filesToRemove []string` instead of single `filename` variable
- Iterates through all provided files and calls `core.RemoveFile` for each
- Tracks exit codes: returns non-zero if any file fails, but attempts all removals

## Proof of Work 
![WhatsApp Image 2026-02-07 at 19 54 02](https://github.com/user-attachments/assets/9482fc8e-0c4e-4b3d-a279-c5aa19f89ce7)
