### PR TITLE
Removed inconsistency and implementation of in branch renaming logic

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -589,9 +589,9 @@ var commands = map[string]CommandFunc{
 				os.Exit(1)
 			}
 			os.Exit(0)
-		case "-r":
+		case "-r", "-m", "--move":
 			if len(args) < 2 {
-				fmt.Fprintln(os.Stderr, "Usage: kitcat branch -r <branch-name>")
+				fmt.Fprintln(os.Stderr, "Usage: kitcat branch -r|-m|--move <branch-name>")
 				os.Exit(2)
 			}
 
@@ -600,6 +600,7 @@ var commands = map[string]CommandFunc{
 				fmt.Println("Error:", err)
 				os.Exit(1)
 			}
+			fmt.Println("Branch renamed to", name)
 			os.Exit(0)
 		case "-d", "--delete":
 			if len(args) < 2 {
@@ -755,17 +756,6 @@ func printCommitResult(newCommit models.Commit, summary string) {
 }
 
 func main() {
-	if len(os.Args) >= 4 && os.Args[1] == "branch" &&
-		(os.Args[2] == "-m" || os.Args[2] == "--move") {
-		newName := os.Args[3]
-		err := core.RenameCurrentBranch(newName)
-		if err != nil {
-			fmt.Println("Error renaming branch:", err)
-			os.Exit(1)
-		}
-		fmt.Println("Branch renamed to", newName)
-		os.Exit(0)
-	}
 	if len(os.Args) < 2 {
 		fmt.Println("Usage: kitcat <command> [args]")
 		os.Exit(2)


### PR DESCRIPTION
Fixes #246 

## Type
- [x] **fix** (Bug fix)
- [ ] **feat** (New capability)
- [ ] **test** (Test-only changes)
- [ ] **chore** (Refactor, docs, or cleanup)

## Description
Consolidated branch rename logic from global `main()` interceptor into the `commands["branch"]` handler for consistency. All rename flags (`-r`, `-m`, `--move`) now work identically and are handled in the same location.

**Changes:**
- Removed ad-hoc argument check in `main()` for `-m`/`--move` flags
- Added `-m` and `--move` cases to `commands["branch"]` switch statement  
- Unified error handling and success messages across all rename flags
- Standardized usage message to show all three flag options

## Proof of Work (REQUIRED)

![WhatsApp Image 2026-02-08 at 20 44 35](https://github.com/user-attachments/assets/b13d8131-8f2d-4ced-a834-7a5bea0f8dd4)
