### PR TITLE
fix: status commands runs properly outside repo

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -210,6 +210,12 @@ var commands = map[string]CommandFunc{
 		}
 	},
 	"status": func(args []string) {
+
+		if !core.IsRepoInitialized() {
+			fmt.Println("Error: not a kitcat repository (or any of the parent directories): .kitcat")
+			os.Exit(1)
+		}
+
 		if err := core.Status(); err != nil {
 			fmt.Println("Error:", err)
 			os.Exit(1)


### PR DESCRIPTION
# Pull Request

## Type
- [ ] **feat** (New capability)
- [ x ] **fix** (Bug fix)
- [ ] **test** (Test-only changes)
- [ ] **chore** (Refactor, docs, or cleanup)

## Description

Previously, running `kitcat status` outside a valid repository produced low-level filesystem errors. 

This update:
- Uses `core.IsRepoInitialized()` at the beginning of the status command handler.
- Prints a clear and consistent error message:
  "Error: not a kitcat repository (or any of the parent directories): .kitcat"
- Exits with status code 1.
- Does not modify core.Status().

## Proof of Work (REQUIRED)
<img width="441" height="152" alt="Screenshot 2026-02-27 232916" src="https://github.com/user-attachments/assets/acfde9e5-bec2-4cc7-ac9d-10ee83f4f95c" />

## Related Issue
Fixes #255

## Checklist
- [ x ] I have run `go fmt ./...` locally
- [ ] My PR contains **exactly one commit** (squashed)
- [ ] I have added/updated tests for this change
- [ ] I have verified that `kitcat` behavior matches Git (if applicable)